### PR TITLE
empty form + i18n

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-10-11 15:39+0200\n"
+"POT-Creation-Date: 2018-10-15 10:09+0200\n"
 "PO-Revision-Date: 2018-10-05 22:07+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -992,6 +992,12 @@ msgstr ""
 
 msgid "configuration_saved"
 msgstr "Configuration saved"
+
+msgid "ucl_management_entity_create_success"
+msgstr "UCL management entity successfully created."
+
+msgid "ucl_management_entity_change_success"
+msgstr "UCL management entity successfully changed."
 
 #~ msgid "Partner"
 #~ msgstr "Partner"

--- a/locale/fr_BE/LC_MESSAGES/django.po
+++ b/locale/fr_BE/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-10-11 15:39+0200\n"
+"POT-Creation-Date: 2018-10-15 10:09+0200\n"
 "PO-Revision-Date: 2018-10-11 15:39+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -987,6 +987,12 @@ msgstr "Accord sauvegardé avec succès."
 
 msgid "configuration_saved"
 msgstr "La configuration à bien été mise à jour."
+
+msgid "ucl_management_entity_create_success"
+msgstr "Entité de gestion UCL créée."
+
+msgid "ucl_management_entity_change_success"
+msgstr "Entités de gestion UCL éditée."
 
 #~ msgid "invalid_partnership_update_max_date"
 #~ msgstr "Date invalide (le 29 février n'est pas autorisé)."

--- a/models.py
+++ b/models.py
@@ -900,12 +900,15 @@ class UCLManagementEntity(models.Model):
         return user_is_adri(user) and not self.faculty.partnerships.exists()
 
     def validate_unique(self, exclude=None):
-        if (self.entity is None):
-            if UCLManagementEntity.objects.exclude(id=self.id).filter(
-                faculty=self.faculty,
-                entity__isnull=True,
-            ).exists():
-                raise ValidationError(_("duplicate_ucl_management_entity_error_with_faculty"))
+        if (self.entity is None):# and hasattr(self, faculty) and self.faculty is not None):
+            try:
+                if UCLManagementEntity.objects.exclude(id=self.id).filter(
+                        faculty=self.faculty,
+                        entity__isnull=True,
+                ).exists():
+                    raise ValidationError(_("duplicate_ucl_management_entity_error_with_faculty"))
+            except Entity.DoesNotExist:
+                pass
         super(UCLManagementEntity, self).validate_unique(exclude)
 
 

--- a/tests/test_ucl_management_entity_create_view.py
+++ b/tests/test_ucl_management_entity_create_view.py
@@ -96,6 +96,12 @@ class UCLManagementEntityCreateViewTest(TestCase):
         response = self.client.post(self.url, data=self.data, follow=True)
         self.assertTemplateUsed(response, 'partnerships/ucl_management_entities/uclmanagemententity_list.html')
 
+    def test_post_adri_no_value(self):
+        self.client.force_login(self.adri_user)
+        response = self.client.post(self.url, data={}, follow=True)
+        self.assertTemplateNotUsed(response, 'partnerships/ucl_management_entities/uclmanagemententity_list.html')
+        self.assertTemplateUsed(response, 'partnerships/ucl_management_entities/uclmanagemententity_create.html')
+
     def test_post_adri_duplicate_faculty_null_entity(self):
         self.client.force_login(self.adri_user)
         data = self.data

--- a/tests/test_ucl_management_entity_update_view.py
+++ b/tests/test_ucl_management_entity_update_view.py
@@ -164,6 +164,12 @@ class UCLManagementEntityUpdateViewTest(TestCase):
         response = self.client.post(self.url, data=self.data, follow=True)
         self.assertTemplateNotUsed(response, 'partnerships/ucl_management_entities/uclmanagemententity_list.html')
 
+    def test_post_adri_no_value(self):
+        self.client.force_login(self.adri_user)
+        response = self.client.post(self.url, data={}, follow=True)
+        self.assertTemplateNotUsed(response, 'partnerships/ucl_management_entities/uclmanagemententity_list.html')
+        self.assertTemplateUsed(response, 'partnerships/ucl_management_entities/uclmanagemententity_update.html')
+
     def test_post_view_adri_user(self):
         self.client.force_login(self.adri_user)
         response = self.client.post(self.url, data=self.data, follow=True)


### PR DESCRIPTION
Handled cases with empty form and no front validator (UCL management entity form) + translation