### PR TITLE
Speed up tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 python: "3.5.5"
+
+cache: pip
+
 services:
   - postgresql
 addons:

--- a/tests/factories/contact.py
+++ b/tests/factories/contact.py
@@ -19,5 +19,4 @@ class ContactFactory(factory.DjangoModelFactory):
     class Meta:
         model = Contact
 
-    type = factory.SubFactory(ContactTypeFactory)
     title = ContactTitle.MISTER.name

--- a/tests/factories/entity_manager.py
+++ b/tests/factories/entity_manager.py
@@ -11,6 +11,9 @@ class PartnershipEntityManagerFactory(factory.DjangoModelFactory):
         model = PartnershipEntityManager
 
     person = factory.SubFactory('base.tests.factories.person.PersonFactory')
-    entity = factory.SubFactory('base.tests.factories.entity.EntityFactory')
+    entity = factory.SubFactory(
+        'base.tests.factories.entity.EntityFactory',
+        organization=None,
+    )
     with_child = True
     scopes = [PartnershipType.MOBILITY.name]

--- a/tests/factories/media.py
+++ b/tests/factories/media.py
@@ -13,4 +13,3 @@ class MediaFactory(factory.DjangoModelFactory):
     description = factory.Faker('sentence')
     url = factory.Faker('url')
     visibility = MediaVisibility.PUBLIC.name
-    author = factory.SubFactory('base.tests.factories.person.PersonFactory')

--- a/tests/factories/partner.py
+++ b/tests/factories/partner.py
@@ -54,23 +54,15 @@ class PartnerFactory(factory.DjangoModelFactory):
     is_nonprofit = factory.Faker('boolean')
     is_public = factory.Faker('boolean')
 
-    author = factory.SubFactory('base.tests.factories.person.PersonFactory')
-
     @factory.post_generation
     def tags(obj, create, extracted, **kwargs):
-        if create:
-            if extracted:
-                obj.tags.set(extracted)
-            else:
-                obj.tags.set([PartnerTagFactory(), PartnerTagFactory()])
+        if create and extracted is not None:
+            obj.tags.set(extracted)
 
     @factory.post_generation
     def entities(obj, create, extracted, **kwargs):
-        if create:
-            if extracted:
-                obj.entities.set(extracted)
-            else:
-                obj.entities.set([PartnerEntityFactory(partner=obj, author=obj.author)])
+        if create and extracted is not None:
+            obj.entities.set(extracted)
 
 
 class PartnerEntityFactory(factory.DjangoModelFactory):
@@ -79,5 +71,4 @@ class PartnerEntityFactory(factory.DjangoModelFactory):
 
     partner = factory.SubFactory(PartnerFactory)
     name = factory.Sequence(lambda n: 'PartnerEntity-é-{0}'.format(n))
-    author = factory.SubFactory('base.tests.factories.person.PersonFactory')
-    address = factory.SubFactory(AddressFactory, country=factory.SelfAttribute('..partner.contact_address.country'))
+    address = factory.SelfAttribute('partner.contact_address')

--- a/tests/factories/partnership.py
+++ b/tests/factories/partnership.py
@@ -1,8 +1,7 @@
 import factory
 
 from partnership.models import Partnership, PartnershipTag, PartnershipType
-from .contact import ContactFactory
-from .partner import PartnerEntityFactory, PartnerFactory
+from .partner import PartnerFactory
 from .partnership_year import PartnershipYearFactory
 
 __all__ = [
@@ -23,34 +22,23 @@ class PartnershipFactory(factory.DjangoModelFactory):
         model = Partnership
 
     partner = factory.SubFactory(PartnerFactory)
-    partner_entity = factory.SubFactory(
-        PartnerEntityFactory,
-        partner=factory.SelfAttribute('..partner'),
-    )
     partnership_type = PartnershipType.MOBILITY.name
 
     ucl_entity = factory.SubFactory(
         'base.tests.factories.entity.EntityFactory',
+        organization=None,
         country=factory.SelfAttribute('..partner.contact_address.country'),
     )
 
-    author = factory.SubFactory('base.tests.factories.person.PersonFactory')
-
     @factory.post_generation
     def tags(obj, create, extracted, **kwargs):
-        if create:
-            if extracted:
-                obj.tags.set(extracted)
-            else:
-                obj.tags.set([PartnershipTagFactory(), PartnershipTagFactory()])
+        if create and extracted is not None:
+            obj.tags.set(extracted)
 
     @factory.post_generation
     def contacts(obj, create, extracted, **kwargs):
-        if create:
-            if extracted:
-                obj.contacts.set(extracted)
-            else:
-                obj.contacts.set([ContactFactory(), ContactFactory()])
+        if create and extracted is not None:
+            obj.contacts.set(extracted)
 
     @factory.post_generation
     def years(obj, create, extracted, **kwargs):

--- a/tests/factories/ucl_management_entity.py
+++ b/tests/factories/ucl_management_entity.py
@@ -11,16 +11,12 @@ class UCLManagementEntityFactory(factory.DjangoModelFactory):
 
     entity = factory.SubFactory(
         'base.tests.factories.entity.EntityFactory',
+        organization=None,
     )
     academic_responsible = factory.SubFactory(
         'base.tests.factories.person.PersonFactory',
     )
-    administrative_responsible = factory.SubFactory(
-        'base.tests.factories.person.PersonFactory'
-    )
-    contact_in_person = factory.SubFactory(
-        'base.tests.factories.person.PersonFactory',
-    )
-    contact_out_person = factory.SubFactory(
-        'base.tests.factories.person.PersonFactory',
-    )
+    # Reuse person to speed up tests
+    administrative_responsible = factory.SelfAttribute('academic_responsible')
+    contact_in_person = factory.SelfAttribute('academic_responsible')
+    contact_out_person = factory.SelfAttribute('academic_responsible')

--- a/tests/views/partner/test_partner_detail_view.py
+++ b/tests/views/partner/test_partner_detail_view.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 
+from base.tests.factories.person import PersonFactory
 from partnership.tests.factories import (
     PartnerFactory,
     PartnershipEntityManagerFactory,
@@ -11,7 +12,7 @@ class PartnerDetailViewTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.partner = PartnerFactory()
+        cls.partner = PartnerFactory(author=PersonFactory())
         cls.user = PartnershipEntityManagerFactory().person.user
         cls.url = reverse('partnerships:partners:detail', kwargs={'pk': cls.partner.pk})
 

--- a/tests/views/partner/test_partner_list_view.py
+++ b/tests/views/partner/test_partner_list_view.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 
 from partnership.tests.factories import (
     PartnerFactory,
-    PartnershipEntityManagerFactory,
+    PartnerTagFactory, PartnershipEntityManagerFactory,
 )
 
 
@@ -27,7 +27,8 @@ class PartnersListViewTest(TestCase):
             end_date=timezone.now() - timedelta(days=1),
             is_ies=False
         )
-        cls.partner_tags = PartnerFactory(is_ies=False)
+        cls.partner_tag = PartnerTagFactory()
+        cls.partner_tags = PartnerFactory(is_ies=False, tags=[cls.partner_tag])
         cls.user = PartnershipEntityManagerFactory().person.user
         cls.url = reverse('partnerships:partners:list')
 
@@ -114,7 +115,7 @@ class PartnersListViewTest(TestCase):
 
     def test_filter_tags(self):
         self.client.force_login(self.user)
-        url = self.url + '?tags={0}'.format(self.partner_tags.tags.all().first().id)
+        url = self.url + '?tags={0}'.format(self.partner_tag.pk)
         response = self.client.get(url)
         self.assertTemplateUsed(response, 'partnerships/partners/partners_list.html')
         context = response.context_data

--- a/tests/views/partnership/test_partnership_agreements_views.py
+++ b/tests/views/partnership/test_partnership_agreements_views.py
@@ -22,7 +22,7 @@ from partnership.tests.factories import (
 class PartnershipAgreementsListViewTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        for i in range(15):
+        for i in range(3):
             PartnershipAgreementFactory()
         cls.user = PartnershipEntityManagerFactory().person.user
         cls.user_adri = UserFactory()


### PR DESCRIPTION
On a 1300+ objets créés par les Factory rien que pour le test de la liste des partenariats (test le plus lent avec ~10s de `setUpTestData()`, je me suis dit que ça commençait à faire un peu trop.

 - J'ai supprimé les SubFactory pas trop utile (notamment les ForeignKey à `null=True`)
 - J'ai rationalisé la création d'objets dans `PartnershipsListViewTest`
 - J'ai modifié les factory qui créaient des objets automatiquement en post-generation (pour préférer le manuel)

Bref, en local :

|           | Avant | Après |
|-----------|-------|-------|
| Parallèle | ~66s  | ~37s  |
| Normal    | ~100s | ~73s  |

J'ai également ajouté le cache de pip sur travis, donc les builds devraient être encore plus rapides.